### PR TITLE
Cube report automation

### DIFF
--- a/unified_solution/README.md
+++ b/unified_solution/README.md
@@ -15,17 +15,17 @@ pip install -r requirements.txt
 
 ### Single PDF
 ```bash
-python cube_automation.py input.pdf output.xlsx
+python -m unified_solution input.pdf output.xlsx
 ```
 
 ### Batch Processing (Folder)
 ```bash
-python cube_automation.py ./pdfs/ --folder --output-dir ./reports/
+python -m unified_solution ./pdfs/ --folder --output-dir ./reports/
 ```
 
 ### Enable Validation
 ```bash
-python cube_automation.py input.pdf output.xlsx --validate
+python -m unified_solution input.pdf output.xlsx --validate
 ```
 
 ## Windows Batch Wrapper

--- a/unified_solution/README.md
+++ b/unified_solution/README.md
@@ -1,0 +1,83 @@
+# Unified Concrete Cube Report Automation
+
+This unified solution converts concrete cube PDF reports directly into formatted Excel workbooks in one command. It combines the existing PDF extraction logic with the Excel formatting workflow, removing the manual CSV import step.
+
+## Requirements
+- Python 3.8+
+- Dependencies listed in `requirements.txt`
+
+## Installation
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+### Single PDF
+```bash
+python cube_automation.py input.pdf output.xlsx
+```
+
+### Batch Processing (Folder)
+```bash
+python cube_automation.py ./pdfs/ --folder --output-dir ./reports/
+```
+
+### Enable Validation
+```bash
+python cube_automation.py input.pdf output.xlsx --validate
+```
+
+## Windows Batch Wrapper
+Use the included batch file for quick batch processing:
+```bat
+process_batch.bat
+```
+
+## Output Workbook Structure
+The output Excel file contains:
+- **Raw** sheet with all extracted data
+- **45D**, **60D**, **45DWP**, **60DWP** sheets with:
+  - Merged pour locations (column G)
+  - Merged every two rows for columns A, B, D, E (matching legacy output)
+
+## Data Format (Raw Sheet)
+Columns:
+1. Cube Mark Prefix
+2. Cube Number
+3. Cube Suffix
+4. Report Number
+5. Date Cast
+6. Compressive Strength (MPa)
+7. Pour Location
+
+## Validation
+When `--validate` is used, the script checks:
+- Missing fields
+- Strength values outside 20–100 MPa
+- Date format (DD-Mon-YYYY)
+- Duplicate cube marks
+
+Validation messages are printed to the console and logged, but output files are still generated so you can review them.
+
+## Logging
+Each run creates a `cube_automation.log` file in the output directory for troubleshooting.
+
+## Troubleshooting
+- **PDF not found**: confirm the file path is correct
+- **No cubes extracted**: check that the PDF contains selectable text and matches the expected report format
+- **Empty output sheets**: confirm cube marks include 45D/60D/45DWP/60DWP identifiers
+
+## Project Structure
+```
+unified_solution/
+├── cube_automation.py
+├── config.py
+├── requirements.txt
+├── process_batch.bat
+├── modules/
+│   ├── pdf_extractor.py
+│   ├── excel_writer.py
+│   └── data_validator.py
+└── templates/
+```

--- a/unified_solution/__init__.py
+++ b/unified_solution/__init__.py
@@ -1,0 +1,3 @@
+"""Unified solution for concrete cube report automation."""
+
+__version__ = "1.0.0"

--- a/unified_solution/__main__.py
+++ b/unified_solution/__main__.py
@@ -1,0 +1,6 @@
+"""Allow running the package as a module with python -m unified_solution."""
+
+from .cube_automation import main
+
+if __name__ == "__main__":
+    main()

--- a/unified_solution/config.py
+++ b/unified_solution/config.py
@@ -1,0 +1,28 @@
+"""Configuration settings for the unified cube automation tool."""
+
+RAW_SHEET = "Raw"
+
+EXCEL_HEADERS = [
+    "Cube Mark Prefix",
+    "Cube Number",
+    "Cube Suffix",
+    "Report Number",
+    "Date Cast",
+    "Compressive Strength (MPa)",
+    "Pour Location",
+]
+
+CONCRETE_TYPES = ["45D", "60D", "45DWP", "60DWP"]
+
+# Validation thresholds
+MIN_STRENGTH = 20.0  # MPa
+MAX_STRENGTH = 100.0  # MPa
+
+# Column letters for merging
+POUR_LOCATION_COL = "G"
+
+# Merge columns to match legacy Excel output
+MERGE_COLS = ["A", "B", "D", "E"]
+
+# Default log file name
+LOG_FILENAME = "cube_automation.log"

--- a/unified_solution/cube_automation.py
+++ b/unified_solution/cube_automation.py
@@ -1,0 +1,155 @@
+"""CLI entry point for unified cube automation."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import config
+from modules.data_validator import validate_cube_data
+from modules.excel_writer import write_to_excel
+from modules.pdf_extractor import extract_cubes_from_pdf
+
+
+def process_single_pdf(
+    pdf_path: str,
+    output_path: str,
+    validate: bool = False,
+    logger: logging.Logger | None = None,
+) -> None:
+    """Process single PDF to Excel."""
+    logger = logger or logging.getLogger(__name__)
+    logger.info("Processing: %s", pdf_path)
+
+    cube_data = extract_cubes_from_pdf(pdf_path)
+    logger.info("Extracted %s cubes", len(cube_data))
+
+    if validate:
+        validation_result = validate_cube_data(cube_data)
+        _log_validation_result(validation_result, logger)
+        if validation_result["errors"]:
+            logger.warning("Validation errors found; output will still be generated.")
+
+    write_to_excel(cube_data, output_path)
+    logger.info("Saved: %s", output_path)
+
+
+def process_batch(
+    folder_path: str,
+    output_dir: str,
+    validate: bool = False,
+    logger: logging.Logger | None = None,
+) -> None:
+    """Process all PDFs in folder."""
+    logger = logger or logging.getLogger(__name__)
+    folder = Path(folder_path)
+    if not folder.exists() or not folder.is_dir():
+        raise FileNotFoundError(f"Folder not found: {folder_path}")
+
+    output_dir_path = Path(output_dir)
+    output_dir_path.mkdir(parents=True, exist_ok=True)
+
+    pdf_files = list({*folder.glob("*.pdf"), *folder.glob("*.PDF")})
+    pdf_files = sorted(pdf_files, key=lambda p: p.name.lower())
+
+    logger.info("Found %s PDF files", len(pdf_files))
+    if not pdf_files:
+        raise ValueError("No PDF files found in folder")
+
+    for idx, pdf_file in enumerate(pdf_files, start=1):
+        output_name = f"{pdf_file.stem}_processed.xlsx"
+        output_path = output_dir_path / output_name
+        logger.info("Processing %s/%s: %s", idx, len(pdf_files), pdf_file.name)
+        try:
+            process_single_pdf(str(pdf_file), str(output_path), validate, logger)
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.error("Error processing %s: %s", pdf_file.name, exc)
+            logger.exception("Stack trace")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Automate concrete cube report processing from PDF to Excel"
+    )
+    parser.add_argument("input", help="Input PDF file or folder path")
+    parser.add_argument(
+        "output", nargs="?", help="Output Excel file path (single file mode)"
+    )
+    parser.add_argument("--folder", action="store_true", help="Process all PDFs in folder")
+    parser.add_argument("--output-dir", help="Output directory for batch processing")
+    parser.add_argument("--validate", action="store_true", help="Enable data validation")
+
+    args = parser.parse_args()
+
+    if args.folder:
+        if not args.output_dir:
+            parser.error("--output-dir is required when using --folder.")
+        log_dir = Path(args.output_dir)
+        log_path = log_dir / config.LOG_FILENAME
+        logger = _setup_logging(log_path)
+        process_batch(args.input, args.output_dir, args.validate, logger)
+    else:
+        if not args.output:
+            parser.error("Output file path is required for single file mode.")
+        log_dir = Path(args.output).parent if args.output else Path.cwd()
+        log_path = log_dir / config.LOG_FILENAME
+        logger = _setup_logging(log_path)
+        process_single_pdf(args.input, args.output, args.validate, logger)
+
+
+def _setup_logging(log_path: Path) -> logging.Logger:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+
+    logger = logging.getLogger()
+    logger.setLevel(logging.INFO)
+    logger.handlers = []
+
+    formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+
+    file_handler = logging.FileHandler(log_path, encoding="utf-8")
+    file_handler.setFormatter(formatter)
+    logger.addHandler(file_handler)
+
+    stream_handler = logging.StreamHandler(sys.stdout)
+    stream_handler.setFormatter(formatter)
+    logger.addHandler(stream_handler)
+
+    logger.info("Log file: %s", log_path)
+    return logger
+
+
+def _log_validation_result(result: dict, logger: logging.Logger) -> None:
+    errors = result.get("errors", [])
+    warnings = result.get("warnings", [])
+    stats = result.get("stats", {})
+
+    if errors:
+        logger.error("Validation errors:")
+        for message in errors:
+            logger.error("  - %s", message)
+
+    if warnings:
+        logger.warning("Validation warnings:")
+        for message in warnings:
+            logger.warning("  - %s", message)
+
+    total = stats.get("total_cubes", 0)
+    logger.info("Validation stats: total_cubes=%s", total)
+    for cube_type, count in stats.get("by_type", {}).items():
+        logger.info("  %s: %s cubes", cube_type, count)
+    for cube_type, avg_strength in stats.get("avg_strength", {}).items():
+        logger.info("  %s: avg_strength=%s MPa", cube_type, avg_strength)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:  # pylint: disable=broad-except
+        logging.getLogger(__name__).exception("Fatal error: %s", exc)
+        sys.exit(1)

--- a/unified_solution/cube_automation.py
+++ b/unified_solution/cube_automation.py
@@ -7,14 +7,10 @@ import logging
 import sys
 from pathlib import Path
 
-SCRIPT_DIR = Path(__file__).resolve().parent
-if str(SCRIPT_DIR) not in sys.path:
-    sys.path.insert(0, str(SCRIPT_DIR))
-
-import config
-from modules.data_validator import validate_cube_data
-from modules.excel_writer import write_to_excel
-from modules.pdf_extractor import extract_cubes_from_pdf
+from . import config
+from .modules.data_validator import validate_cube_data
+from .modules.excel_writer import write_to_excel
+from .modules.pdf_extractor import extract_cubes_from_pdf
 
 
 def process_single_pdf(
@@ -24,7 +20,7 @@ def process_single_pdf(
     logger: logging.Logger | None = None,
 ) -> None:
     """Process single PDF to Excel."""
-    logger = logger or logging.getLogger(__name__)
+    logger = logger or logging.getLogger("cube_automation")
     logger.info("Processing: %s", pdf_path)
 
     cube_data = extract_cubes_from_pdf(pdf_path)
@@ -47,7 +43,7 @@ def process_batch(
     logger: logging.Logger | None = None,
 ) -> None:
     """Process all PDFs in folder."""
-    logger = logger or logging.getLogger(__name__)
+    logger = logger or logging.getLogger("cube_automation")
     folder = Path(folder_path)
     if not folder.exists() or not folder.is_dir():
         raise FileNotFoundError(f"Folder not found: {folder_path}")
@@ -106,7 +102,7 @@ def main() -> None:
 def _setup_logging(log_path: Path) -> logging.Logger:
     log_path.parent.mkdir(parents=True, exist_ok=True)
 
-    logger = logging.getLogger()
+    logger = logging.getLogger("cube_automation")
     logger.setLevel(logging.INFO)
     logger.handlers = []
 
@@ -151,5 +147,5 @@ if __name__ == "__main__":
     try:
         main()
     except Exception as exc:  # pylint: disable=broad-except
-        logging.getLogger(__name__).exception("Fatal error: %s", exc)
+        logging.getLogger("cube_automation").exception("Fatal error: %s", exc)
         sys.exit(1)

--- a/unified_solution/cube_automation.py
+++ b/unified_solution/cube_automation.py
@@ -116,6 +116,18 @@ def _setup_logging(log_path: Path) -> logging.Logger:
     stream_handler.setFormatter(formatter)
     logger.addHandler(stream_handler)
 
+    # Also configure the pdf_extractor module logger to use the same handlers
+    # so per-page cube counts appear in the log
+    module_logger = logging.getLogger("unified_solution.modules.pdf_extractor")
+    module_logger.setLevel(logging.INFO)
+    module_logger.handlers = []
+    module_logger.propagate = False  # Prevent duplicate logs
+    # Create separate handlers for the module logger pointing to the same file
+    module_file_handler = logging.FileHandler(log_path, encoding="utf-8")
+    module_file_handler.setFormatter(formatter)
+    module_logger.addHandler(module_file_handler)
+    module_logger.addHandler(stream_handler)
+
     logger.info("Log file: %s", log_path)
     return logger
 

--- a/unified_solution/modules/__init__.py
+++ b/unified_solution/modules/__init__.py
@@ -1,0 +1,1 @@
+"""Module package for unified cube automation."""

--- a/unified_solution/modules/data_validator.py
+++ b/unified_solution/modules/data_validator.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Dict, List
+from typing import Any, Dict, List, Optional
 
-import config
+from .. import config
 
 
 EXPECTED_FIELDS = [
@@ -85,7 +85,7 @@ def validate_cube_data(cube_data: List[Dict[str, str]]) -> Dict[str, object]:
             if not _is_valid_date(date_cast):
                 warnings.append(f"Row {idx}: invalid date_cast '{date_cast}'")
 
-        cube_type = _get_concrete_type(prefix)
+        cube_type = get_concrete_type(prefix)
         counts_by_type[cube_type] = counts_by_type.get(cube_type, 0) + 1
         if strength is not None:
             strength_by_type.setdefault(cube_type, []).append(strength)
@@ -103,7 +103,7 @@ def validate_cube_data(cube_data: List[Dict[str, str]]) -> Dict[str, object]:
     return {"errors": errors, "warnings": warnings, "stats": stats}
 
 
-def _parse_strength(value):
+def _parse_strength(value: Any) -> Optional[float]:
     if value in ("", None):
         return None
     try:
@@ -120,8 +120,9 @@ def _is_valid_date(value: str) -> bool:
         return False
 
 
-def _get_concrete_type(mark: str) -> str:
-    mark = (mark or "").upper()
+def get_concrete_type(cube_mark_prefix: str) -> str:
+    """Determine concrete type from cube mark prefix."""
+    mark = (cube_mark_prefix or "").upper()
     is45 = "45D" in mark
     is60 = "60D" in mark
     is_wp = "WP" in mark

--- a/unified_solution/modules/data_validator.py
+++ b/unified_solution/modules/data_validator.py
@@ -1,0 +1,136 @@
+"""Validation logic for extracted cube data."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, List
+
+import config
+
+
+EXPECTED_FIELDS = [
+    "cube_mark_prefix",
+    "cube_number",
+    "cube_suffix",
+    "report_number",
+    "date_cast",
+    "compressive_strength",
+    "pour_location",
+]
+
+CRITICAL_FIELDS = [
+    "cube_mark_prefix",
+    "cube_number",
+    "cube_suffix",
+    "compressive_strength",
+]
+
+
+def validate_cube_data(cube_data: List[Dict[str, str]]) -> Dict[str, object]:
+    """
+    Validate extracted cube data for common issues.
+
+    Returns:
+        {
+            "errors": [],      # Critical issues
+            "warnings": [],    # Non-critical issues
+            "stats": {}        # Summary statistics
+        }
+    """
+    errors: List[str] = []
+    warnings: List[str] = []
+
+    seen_marks = set()
+    counts_by_type: Dict[str, int] = {}
+    strength_by_type: Dict[str, List[float]] = {}
+
+    for idx, cube in enumerate(cube_data, start=1):
+        missing = [
+            field
+            for field in EXPECTED_FIELDS
+            if field not in cube or cube.get(field) in ("", None)
+        ]
+        for field in missing:
+            message = f"Row {idx}: missing {field}"
+            if field in CRITICAL_FIELDS:
+                errors.append(message)
+            else:
+                warnings.append(message)
+
+        prefix = cube.get("cube_mark_prefix", "")
+        number = cube.get("cube_number", "")
+        suffix = cube.get("cube_suffix", "")
+        mark = f"{prefix}{number}{suffix}"
+        if mark:
+            if mark in seen_marks:
+                warnings.append(f"Row {idx}: duplicate cube mark '{mark}'")
+            seen_marks.add(mark)
+
+        strength_value = cube.get("compressive_strength", "")
+        strength = _parse_strength(strength_value)
+        if strength is None:
+            if strength_value not in ("", None):
+                warnings.append(
+                    f"Row {idx}: invalid compressive strength '{strength_value}'"
+                )
+        else:
+            if strength < config.MIN_STRENGTH or strength > config.MAX_STRENGTH:
+                warnings.append(
+                    f"Row {idx}: strength {strength} MPa outside "
+                    f"{config.MIN_STRENGTH}-{config.MAX_STRENGTH} MPa"
+                )
+
+        date_cast = cube.get("date_cast", "")
+        if date_cast:
+            if not _is_valid_date(date_cast):
+                warnings.append(f"Row {idx}: invalid date_cast '{date_cast}'")
+
+        cube_type = _get_concrete_type(prefix)
+        counts_by_type[cube_type] = counts_by_type.get(cube_type, 0) + 1
+        if strength is not None:
+            strength_by_type.setdefault(cube_type, []).append(strength)
+
+    stats = {
+        "total_cubes": len(cube_data),
+        "by_type": counts_by_type,
+        "avg_strength": {
+            t: round(sum(vals) / len(vals), 2)
+            for t, vals in strength_by_type.items()
+            if vals
+        },
+    }
+
+    return {"errors": errors, "warnings": warnings, "stats": stats}
+
+
+def _parse_strength(value):
+    if value in ("", None):
+        return None
+    try:
+        return float(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+
+
+def _is_valid_date(value: str) -> bool:
+    try:
+        datetime.strptime(value.strip().title(), "%d-%b-%Y")
+        return True
+    except ValueError:
+        return False
+
+
+def _get_concrete_type(mark: str) -> str:
+    mark = (mark or "").upper()
+    is45 = "45D" in mark
+    is60 = "60D" in mark
+    is_wp = "WP" in mark
+    if is45 and is_wp:
+        return "45DWP"
+    if is60 and is_wp:
+        return "60DWP"
+    if is45:
+        return "45D"
+    if is60:
+        return "60D"
+    return "Unknown"

--- a/unified_solution/modules/excel_writer.py
+++ b/unified_solution/modules/excel_writer.py
@@ -1,0 +1,148 @@
+"""Excel writing and formatting logic."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from openpyxl import Workbook
+from openpyxl.styles import Alignment
+from openpyxl.worksheet.worksheet import Worksheet
+
+import config
+
+
+def write_to_excel(cube_data: List[Dict[str, str]], output_path: str) -> None:
+    """
+    Write cube data to formatted Excel workbook.
+
+    Steps:
+    1. Create workbook with "Raw" sheet containing all data
+    2. Split into sheets: 45D, 60D, 45DWP, 60DWP
+    3. Apply cell merging for pour locations (column G)
+    4. Merge every two rows in configured columns
+    """
+    wb = Workbook()
+    wb.active.title = config.RAW_SHEET
+
+    create_raw_sheet(wb, cube_data)
+    split_by_type(wb)
+
+    for name in config.CONCRETE_TYPES:
+        if name not in wb.sheetnames:
+            continue
+        ws = wb[name]
+        for col in config.MERGE_COLS:
+            merge_every_two(ws, col)
+        merge_pour_locations(ws, config.POUR_LOCATION_COL)
+
+    wb.save(output_path)
+
+
+def get_concrete_type(cube_mark_prefix: str) -> str:
+    """Determine concrete type from cube mark prefix."""
+    mark = (cube_mark_prefix or "").upper()
+    is45 = "45D" in mark
+    is60 = "60D" in mark
+    is_wp = "WP" in mark
+    if is45 and is_wp:
+        return "45DWP"
+    if is60 and is_wp:
+        return "60DWP"
+    if is45:
+        return "45D"
+    if is60:
+        return "60D"
+    return "Unknown"
+
+
+def create_raw_sheet(wb: Workbook, cube_data: List[Dict[str, str]]) -> None:
+    """Create Raw sheet with all cube data."""
+    ws = _create_or_clear(config.RAW_SHEET, wb)
+    ws.append(config.EXCEL_HEADERS)
+
+    for cube in cube_data:
+        ws.append(
+            [
+                cube.get("cube_mark_prefix", ""),
+                _maybe_int(cube.get("cube_number", "")),
+                cube.get("cube_suffix", ""),
+                cube.get("report_number", ""),
+                cube.get("date_cast", ""),
+                _maybe_float(cube.get("compressive_strength", "")),
+                cube.get("pour_location", ""),
+            ]
+        )
+
+
+def split_by_type(wb: Workbook) -> None:
+    """Split Raw sheet into type-specific sheets."""
+    src = wb[config.RAW_SHEET]
+    header = [cell.value for cell in src[1]]
+    targets = {t: _create_or_clear(t, wb) for t in config.CONCRETE_TYPES}
+    for t_ws in targets.values():
+        t_ws.append(header)
+
+    for row in src.iter_rows(min_row=2, values_only=False):
+        mark = row[0].value
+        t_type = get_concrete_type(mark)
+        if t_type in targets:
+            targets[t_type].append([cell.value for cell in row])
+
+
+def merge_pour_locations(ws: Worksheet, col_letter: str = "G") -> None:
+    """Merge consecutive cells with same pour location."""
+    col = ws[col_letter]
+    i, last = 2, ws.max_row
+    while i <= last:
+        start = i
+        curr = ws[f"{col_letter}{i}"].value
+        while i <= last and ws[f"{col_letter}{i}"].value == curr:
+            i += 1
+        if i - start > 1:
+            ws.merge_cells(
+                start_row=start,
+                start_column=col[0].column,
+                end_row=i - 1,
+                end_column=col[0].column,
+            )
+            _set_vertical_center(ws[f"{col_letter}{start}"])
+
+
+def merge_every_two(ws: Worksheet, col_letter: str) -> None:
+    """Merge every two rows in specified column."""
+    for row in range(2, ws.max_row, 2):
+        if row + 1 <= ws.max_row:
+            ws.merge_cells(f"{col_letter}{row}:{col_letter}{row + 1}")
+            _set_vertical_center(ws[f"{col_letter}{row}"])
+
+
+def _create_or_clear(ws_name: str, wb: Workbook) -> Worksheet:
+    if ws_name in wb.sheetnames:
+        ws = wb[ws_name]
+        if ws.max_row:
+            ws.delete_rows(1, ws.max_row)
+    else:
+        ws = wb.create_sheet(title=ws_name)
+    return ws
+
+
+def _set_vertical_center(cell) -> None:
+    cell.alignment = cell.alignment.copy(vertical="center")
+
+
+def _maybe_int(value):
+    if value is None or value == "":
+        return ""
+    try:
+        return int(str(value).strip())
+    except (TypeError, ValueError):
+        return value
+
+
+def _maybe_float(value):
+    if value is None or value == "":
+        return ""
+    try:
+        return float(str(value).strip())
+    except (TypeError, ValueError):
+        return value

--- a/unified_solution/modules/excel_writer.py
+++ b/unified_solution/modules/excel_writer.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Dict, List
+from typing import Any, Dict, List, Union
 
 from openpyxl import Workbook
 from openpyxl.styles import Alignment
 from openpyxl.worksheet.worksheet import Worksheet
 
-import config
+from .. import config
+from .data_validator import get_concrete_type
 
 
 def write_to_excel(cube_data: List[Dict[str, str]], output_path: str) -> None:
@@ -36,23 +37,6 @@ def write_to_excel(cube_data: List[Dict[str, str]], output_path: str) -> None:
         merge_pour_locations(ws, config.POUR_LOCATION_COL)
 
     wb.save(output_path)
-
-
-def get_concrete_type(cube_mark_prefix: str) -> str:
-    """Determine concrete type from cube mark prefix."""
-    mark = (cube_mark_prefix or "").upper()
-    is45 = "45D" in mark
-    is60 = "60D" in mark
-    is_wp = "WP" in mark
-    if is45 and is_wp:
-        return "45DWP"
-    if is60 and is_wp:
-        return "60DWP"
-    if is45:
-        return "45D"
-    if is60:
-        return "60D"
-    return "Unknown"
 
 
 def create_raw_sheet(wb: Workbook, cube_data: List[Dict[str, str]]) -> None:
@@ -130,7 +114,7 @@ def _set_vertical_center(cell) -> None:
     cell.alignment = cell.alignment.copy(vertical="center")
 
 
-def _maybe_int(value):
+def _maybe_int(value: Any) -> Union[int, str]:
     if value is None or value == "":
         return ""
     try:
@@ -139,7 +123,7 @@ def _maybe_int(value):
         return value
 
 
-def _maybe_float(value):
+def _maybe_float(value: Any) -> Union[float, str]:
     if value is None or value == "":
         return ""
     try:

--- a/unified_solution/modules/pdf_extractor.py
+++ b/unified_solution/modules/pdf_extractor.py
@@ -1,0 +1,280 @@
+"""PDF extraction logic for concrete cube reports."""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+try:
+    import pdfplumber
+except ImportError as exc:  # pragma: no cover - handled at runtime
+    raise ImportError(
+        "pdfplumber is required. Install with: pip install pdfplumber"
+    ) from exc
+
+logger = logging.getLogger(__name__)
+
+
+def parse_cube_mark(cube_mark: str) -> Tuple[str, str, str]:
+    """
+    Split cube mark into prefix, number, and suffix components.
+
+    Example:
+        "20250621-45D-1A" -> ("20250621-45D-", "1", "A")
+    """
+    pattern = r"^(.+?-)(\d+)([A-Z])$"
+    match = re.match(pattern, cube_mark or "")
+    if match:
+        return match.group(1), match.group(2), match.group(3)
+
+    logger.warning("Could not parse cube mark '%s'", cube_mark)
+    return cube_mark or "", "", ""
+
+
+def extract_cubes_from_pdf(pdf_path: str) -> List[Dict[str, str]]:
+    """
+    Extract cube data from PDF report.
+
+    Returns:
+        List of dictionaries with keys:
+        - cube_mark_prefix, cube_number, cube_suffix
+        - report_number, date_cast, compressive_strength, pour_location
+    """
+    path = Path(pdf_path)
+    if not path.exists():
+        raise FileNotFoundError(f"PDF not found: {pdf_path}")
+
+    all_cubes: List[Dict[str, str]] = []
+    try:
+        with pdfplumber.open(str(path)) as pdf:
+            for page_number, page in enumerate(pdf.pages, start=1):
+                try:
+                    page_text = page.extract_text() or ""
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to extract text from page %s: %s",
+                        page_number,
+                        exc,
+                    )
+                    continue
+
+                cubes = _extract_all_cubes_from_text(page_text)
+                if cubes:
+                    logger.info("Page %s: %s cubes extracted", page_number, len(cubes))
+                    all_cubes.extend(cubes)
+                else:
+                    logger.info("Page %s: no cubes found", page_number)
+    except Exception as exc:  # pragma: no cover - external dependency errors
+        raise RuntimeError(f"Failed to process PDF '{pdf_path}': {exc}") from exc
+
+    if not all_cubes:
+        raise ValueError("No cube data extracted from PDF")
+
+    return all_cubes
+
+
+def _extract_report_number(text: str) -> str:
+    patterns = [
+        r"Report\s+No\.?:?\s*([A-Z0-9]+)",
+        r"Report\s+Number:?\s*([A-Z0-9]+)",
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, text, re.IGNORECASE)
+        if match:
+            return match.group(1)
+    return ""
+
+
+def _extract_date_cast(text: str) -> str:
+    pattern = r"(?:Date\s+Cast\s*:\s*)(\d{2}-[A-Za-z]{3}-\d{4})"
+    match = re.search(pattern, text, re.IGNORECASE)
+    if match:
+        return match.group(1)
+    return ""
+
+
+def _extract_pour_location(text: str) -> str:
+    patterns = [
+        r"(?:Pour\sLocation|Location)\s*:\s*(.+?)(?=\nDate\sCast|\Z)",
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, text, re.IGNORECASE | re.DOTALL)
+        if match:
+            location = match.group(1).strip()
+            return " ".join(location.split())
+    return ""
+
+
+def _build_cube_record(
+    prefix: str,
+    number: str,
+    suffix: str,
+    report_number: str,
+    date_cast: str,
+    strength: str,
+    pour_location: str,
+) -> Dict[str, str]:
+    return {
+        "cube_mark_prefix": prefix,
+        "cube_number": number,
+        "cube_suffix": suffix,
+        "report_number": report_number,
+        "date_cast": date_cast,
+        "compressive_strength": strength,
+        "pour_location": pour_location,
+    }
+
+
+def _extract_all_cubes_from_text(page_text: str) -> List[Dict[str, str]]:
+    if not page_text:
+        return []
+
+    cubes: List[Dict[str, str]] = []
+    report_number = _extract_report_number(page_text)
+    date_cast = _extract_date_cast(page_text)
+    pour_location = _extract_pour_location(page_text)
+
+    lines = page_text.split("\n")
+    i = 0
+    while i < len(lines):
+        line = lines[i].strip()
+
+        case1_match = re.search(
+            r"CU\d+\s+(\d{8}-\d+[A-Z]+-\d+[A-Z])\s+.*?\s+(\d+\.?\d*)\s+(\d+\.?\d*)\s+S\s+-",
+            line,
+        )
+        if case1_match:
+            full_cube_mark = case1_match.group(1)
+            strength = case1_match.group(3)
+            prefix, number, suffix = parse_cube_mark(full_cube_mark)
+            cubes.append(
+                _build_cube_record(
+                    prefix,
+                    number,
+                    suffix,
+                    report_number,
+                    date_cast,
+                    strength,
+                    pour_location,
+                )
+            )
+            i += 1
+            continue
+
+        case2_match = re.search(
+            r"CU\d+\s+(\d{8}-\d+[A-Z]+-\d+)\s+.*?\s+(\d+\.?\d*)\s+(\d+\.?\d*)\s+S\s+-",
+            line,
+        )
+        if case2_match:
+            if i + 1 < len(lines):
+                next_line = lines[i + 1].strip()
+                if len(next_line) == 1 and next_line.isalpha() and next_line.isupper():
+                    cube_mark_base = case2_match.group(1)
+                    strength = case2_match.group(3)
+                    suffix = next_line
+                    full_cube_mark = f"{cube_mark_base}{suffix}"
+                    prefix, number, _ = parse_cube_mark(full_cube_mark)
+                    cubes.append(
+                        _build_cube_record(
+                            prefix,
+                            number,
+                            suffix,
+                            report_number,
+                            date_cast,
+                            strength,
+                            pour_location,
+                        )
+                    )
+                    i += 2
+                    continue
+
+        case3_match = re.search(
+            r"CU\d+\s+(\d{8}-\d+[A-Z]+-)\s+.*?\s+(\d+\.?\d*)\s+(\d+\.?\d*)\s+S\s+-",
+            line,
+        )
+        if case3_match:
+            if i + 1 < len(lines):
+                next_line = lines[i + 1].strip()
+                id_match = re.match(r"(\d+)([A-Z])$", next_line)
+                if id_match:
+                    cube_mark_base = case3_match.group(1)
+                    number = id_match.group(1)
+                    suffix = id_match.group(2)
+                    strength = case3_match.group(3)
+                    cubes.append(
+                        _build_cube_record(
+                            cube_mark_base,
+                            number,
+                            suffix,
+                            report_number,
+                            date_cast,
+                            strength,
+                            pour_location,
+                        )
+                    )
+                    i += 2
+                    continue
+
+        case4_match = re.search(
+            r"CU\d+\s+(\d{8}-\d+[A-Z]+)\s+.*?\s+(\d+\.?\d*)\s+(\d+\.?\d*)\s+S\s+-",
+            line,
+        )
+        if case4_match:
+            if i + 1 < len(lines):
+                next_line = lines[i + 1].strip()
+                id_match = re.match(r"-\s*(\d+)([A-Z])$", next_line)
+                if id_match:
+                    cube_mark_base = case4_match.group(1)
+                    number = id_match.group(1)
+                    suffix = id_match.group(2)
+                    strength = case4_match.group(3)
+                    full_cube_mark = f"{cube_mark_base}-{number}{suffix}"
+                    prefix, _, _ = parse_cube_mark(full_cube_mark)
+                    cubes.append(
+                        _build_cube_record(
+                            prefix,
+                            number,
+                            suffix,
+                            report_number,
+                            date_cast,
+                            strength,
+                            pour_location,
+                        )
+                    )
+                    i += 2
+                    continue
+
+        case5_match = re.search(
+            r"CU\d+\s+(\d{8}-\d+[A-Z]+)\s+.*?\s+(\d+\.?\d*)\s+(\d+\.?\d*)\s+S\s+-",
+            line,
+        )
+        if case5_match:
+            if i + 2 < len(lines):
+                next_next_line = lines[i + 2].strip()
+                id_match = re.match(r"-\s*(\d+)([A-Z])$", next_next_line)
+                if id_match:
+                    cube_mark_base = case5_match.group(1)
+                    number = id_match.group(1)
+                    suffix = id_match.group(2)
+                    strength = case5_match.group(3)
+                    full_cube_mark = f"{cube_mark_base}-{number}{suffix}"
+                    prefix, _, _ = parse_cube_mark(full_cube_mark)
+                    cubes.append(
+                        _build_cube_record(
+                            prefix,
+                            number,
+                            suffix,
+                            report_number,
+                            date_cast,
+                            strength,
+                            pour_location,
+                        )
+                    )
+                    i += 3
+                    continue
+
+        i += 1
+
+    return cubes

--- a/unified_solution/process_batch.bat
+++ b/unified_solution/process_batch.bat
@@ -6,6 +6,6 @@ echo.
 set /p INPUT_FOLDER="Enter PDF folder path: "
 set /p OUTPUT_FOLDER="Enter output folder path: "
 
-python cube_automation.py "%INPUT_FOLDER%" --folder --output-dir "%OUTPUT_FOLDER%" --validate
+python -m unified_solution "%INPUT_FOLDER%" --folder --output-dir "%OUTPUT_FOLDER%" --validate
 
 pause

--- a/unified_solution/process_batch.bat
+++ b/unified_solution/process_batch.bat
@@ -1,0 +1,11 @@
+@echo off
+echo Concrete Cube Report Batch Processor
+echo ====================================
+echo.
+
+set /p INPUT_FOLDER="Enter PDF folder path: "
+set /p OUTPUT_FOLDER="Enter output folder path: "
+
+python cube_automation.py "%INPUT_FOLDER%" --folder --output-dir "%OUTPUT_FOLDER%" --validate
+
+pause

--- a/unified_solution/requirements.txt
+++ b/unified_solution/requirements.txt
@@ -1,0 +1,2 @@
+pdfplumber>=0.10.0
+openpyxl>=3.1.2

--- a/unified_solution/templates/.gitkeep
+++ b/unified_solution/templates/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to keep templates directory in version control


### PR DESCRIPTION
Implement a unified Python solution to automate concrete cube report processing from PDF to formatted Excel.

This eliminates manual CSV conversion steps, streamlining the workflow for daily use.

---
<a href="https://cursor.com/background-agent?bcId=bc-f374a968-73a5-40a5-9477-3675164124b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f374a968-73a5-40a5-9477-3675164124b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New end-to-end parsing/formatting pipeline and CLI are additive but rely on regex-based PDF text extraction and Excel cell merging, which may be brittle across report format variations.
> 
> **Overview**
> Adds a new `unified_solution` Python package/CLI that converts concrete cube PDF reports directly into formatted Excel workbooks, including single-file and folder batch modes (`python -m unified_solution ...`).
> 
> Implements PDF text extraction via `pdfplumber` with multiple parsing cases, optional `--validate` checks (missing fields, strength/date ranges, duplicates) with stats logging, and Excel generation via `openpyxl` that produces a `Raw` sheet plus type-specific sheets (`45D`/`60D`/`45DWP`/`60DWP`) with legacy-style cell merging.
> 
> Includes documentation, a Windows batch wrapper, and pins runtime dependencies in `requirements.txt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab29a2d2ede8149700cb59f460be0984e69e55c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->