### PR TITLE
New PDF parsing usecase

### DIFF
--- a/unified_solution/modules/pdf_extractor.py
+++ b/unified_solution/modules/pdf_extractor.py
@@ -224,6 +224,32 @@ def _handle_case5(
     return cube, i + 3
 
 
+def _handle_case6(
+    match: re.Match, lines: List[str], i: int, report_number: str, date_cast: str, pour_location: str
+) -> Optional[Tuple[Dict[str, str], int]]:
+    """Handle case 6: Partial cube mark with dash+number+suffix on same line after a space.
+
+    Example line:
+        CU073184 20260119-45D -1A 45D 125 / 125 100.1 x 100.2 x 100.1 2.377 2370 639.3 63.7 S -
+
+    The cube mark base (e.g. '20260119-45D') and the identifier part (e.g. '-1A') appear
+    on the same line separated by whitespace, unlike cases 4/5 where the identifier is on
+    a subsequent line.
+    """
+    cube_mark_base = match.group(1)
+    id_part = match.group(2)
+    strength = match.group(4)
+    id_match = re.match(r"-(\d+)([A-Z])$", id_part)
+    if not id_match:
+        return None
+    number = id_match.group(1)
+    suffix = id_match.group(2)
+    full_cube_mark = f"{cube_mark_base}-{number}{suffix}"
+    prefix, _, _ = parse_cube_mark(full_cube_mark)
+    cube = _build_cube_record(prefix, number, suffix, report_number, date_cast, strength, pour_location)
+    return cube, i + 1
+
+
 def _get_parsing_cases(report_number: str, date_cast: str, pour_location: str) -> List[ParsingCase]:
     """Define all parsing cases with their patterns and handlers."""
     return [
@@ -241,6 +267,11 @@ def _get_parsing_cases(report_number: str, date_cast: str, pour_location: str) -
             name="case3_number_suffix_next_line",
             pattern=r"CU\d+\s+(\d{8}-\d+[A-Z]+-)\s+.*?\s+(\d+\.?\d*)\s+(\d+\.?\d*)\s+S\s+-",
             handler=lambda m, l, i: _handle_case3(m, l, i, report_number, date_cast, pour_location),
+        ),
+        ParsingCase(
+            name="case6_dash_number_suffix_same_line",
+            pattern=r"CU\d+\s+(\d{8}-\d+[A-Z]+)\s+(-\d+[A-Z])\s+.*?\s+(\d+\.?\d*)\s+(\d+\.?\d*)\s+S\s+-",
+            handler=lambda m, l, i: _handle_case6(m, l, i, report_number, date_cast, pour_location),
         ),
         ParsingCase(
             name="case4_dash_number_suffix_next_line",

--- a/unified_solution/modules/pdf_extractor.py
+++ b/unified_solution/modules/pdf_extractor.py
@@ -237,13 +237,9 @@ def _handle_case6(
     a subsequent line.
     """
     cube_mark_base = match.group(1)
-    id_part = match.group(2)
-    strength = match.group(4)
-    id_match = re.match(r"-(\d+)([A-Z])$", id_part)
-    if not id_match:
-        return None
-    number = id_match.group(1)
-    suffix = id_match.group(2)
+    number = match.group(2)
+    suffix = match.group(3)
+    strength = match.group(5)
     full_cube_mark = f"{cube_mark_base}-{number}{suffix}"
     prefix, _, _ = parse_cube_mark(full_cube_mark)
     cube = _build_cube_record(prefix, number, suffix, report_number, date_cast, strength, pour_location)
@@ -270,7 +266,7 @@ def _get_parsing_cases(report_number: str, date_cast: str, pour_location: str) -
         ),
         ParsingCase(
             name="case6_dash_number_suffix_same_line",
-            pattern=r"CU\d+\s+(\d{8}-\d+[A-Z]+)\s+(-\d+[A-Z])\s+.*?\s+(\d+\.?\d*)\s+(\d+\.?\d*)\s+S\s+-",
+            pattern=r"CU\d+\s+(\d{8}-\d+[A-Z]+)\s+-(\d+)([A-Z])\s+.*?\s+(\d+\.?\d*)\s+(\d+\.?\d*)\s+S\s+-",
             handler=lambda m, l, i: _handle_case6(m, l, i, report_number, date_cast, pour_location),
         ),
         ParsingCase(

--- a/unified_solution/modules/pdf_extractor.py
+++ b/unified_solution/modules/pdf_extractor.py
@@ -240,8 +240,7 @@ def _handle_case6(
     number = match.group(2)
     suffix = match.group(3)
     strength = match.group(5)
-    full_cube_mark = f"{cube_mark_base}-{number}{suffix}"
-    prefix, _, _ = parse_cube_mark(full_cube_mark)
+    prefix = f"{cube_mark_base}-"
     cube = _build_cube_record(prefix, number, suffix, report_number, date_cast, strength, pour_location)
     return cube, i + 1
 
@@ -266,7 +265,7 @@ def _get_parsing_cases(report_number: str, date_cast: str, pour_location: str) -
         ),
         ParsingCase(
             name="case6_dash_number_suffix_same_line",
-            pattern=r"CU\d+\s+(\d{8}-\d+[A-Z]+)\s+-(\d+)([A-Z])\s+.*?\s+(\d+\.?\d*)\s+(\d+\.?\d*)\s+S\s+-",
+            pattern=r"CU\d+\s+(\d{8}-\d+[A-Z]+)\s+-\s*(\d+)([A-Z])\s+.*?\s+(\d+\.?\d*)\s+(\d+\.?\d*)\s+S\s+-",
             handler=lambda m, l, i: _handle_case6(m, l, i, report_number, date_cast, pour_location),
         ),
         ParsingCase(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add new parsing case to handle cube marks where the suffix is on the same line but separated by a space.

This new case (Case 6) prevents silent dropping of records that would be partially matched by existing, less specific parsing cases (4 and 5) which expect the suffix on a subsequent line.

<div><a href="https://cursor.com/agents/bc-62028755-0b85-4d08-8ef6-eb67dafba77b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62028755-0b85-4d08-8ef6-eb67dafba77b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->